### PR TITLE
feat: add Notification Centre with history panel and IPC controls

### DIFF
--- a/DynamicIslandWindow.qml
+++ b/DynamicIslandWindow.qml
@@ -122,6 +122,7 @@ PanelWindow {
         ? Math.ceil(userConfig.islandTopMargin + root.overviewCapsuleHeight + 8)
         : 0
     readonly property real requestedWindowHeight: Math.max(
+        root.notificationCenterWindowHeight,
         root.capsuleWindowHeight,
         root.connectivityDetailWindowHeight,
         root.overviewWindowHeight,
@@ -242,6 +243,10 @@ PanelWindow {
         : 120
     readonly property real controlCenterWindowHeight: islandContainer.controlCenterLayerVisible
         ? userConfig.islandTopMargin + 320 + root.controlCenterMaximumExtraHeight + 12
+        : 0
+
+    readonly property real notificationCenterWindowHeight: islandContainer.notificationCenterLayerVisible
+        ? userConfig.islandTopMargin + (notificationCenterLoader.item ? notificationCenterLoader.item.contentHeight : 400) + 6
         : 0
     readonly property real connectivityDetailGap: 16
     readonly property int connectivityDetailAnimationDuration: 360
@@ -547,6 +552,13 @@ PanelWindow {
             islandContainer.showControlCenter();
     }
 
+    function toggleNotificationCenterWindow() {
+        if (islandContainer.islandState === "notification_center")
+            islandContainer.smartRestoreState();
+        else
+            islandContainer.showNotificationCenter();
+    }
+
     function toggleWallpaperPickerWindow() {
         if (islandContainer.islandState === "wallpaper_picker")
             islandContainer.smartRestoreState();
@@ -713,6 +725,7 @@ PanelWindow {
         property string notificationBody: ""
         property bool notificationExpanded: false
         property var bluetoothExpandedDevice: null
+        property var notificationHistoryModel: ListModel {}
         readonly property var cavaLevels: systemState.cavaLevels
         property real swipeTransitionProgress: 0
         property string workspaceOriginSide: "none"
@@ -789,6 +802,7 @@ PanelWindow {
         readonly property bool bluetoothExpandedLayerVisible: !root.overviewVisible && islandState === "bluetooth_expanded"
         readonly property bool notificationLayerVisible: !root.overviewVisible && islandState === "notification"
         readonly property bool controlCenterLayerVisible: !root.overviewVisible && islandState === "control_center"
+        readonly property bool notificationCenterLayerVisible: !root.overviewVisible && islandState === "notification_center"
         readonly property bool wallpaperPickerLayerVisible: !root.overviewVisible && islandState === "wallpaper_picker"
         readonly property var activePlayer: mediaController.activePlayer
         readonly property string lyricsDisplayText: mediaController.displayText
@@ -927,6 +941,19 @@ PanelWindow {
                 return;
             case "closeExpandedPlayer":
                 if (islandState === "expanded")
+                    smartRestoreState();
+                return;
+            case "toggleNotificationCenter":
+                if (islandState === "notification_center")
+                    smartRestoreState();
+                else
+                    showNotificationCenter();
+                return;
+            case "openNotificationCenter":
+                showNotificationCenter();
+                return;
+            case "closeNotificationCenter":
+                if (islandState === "notification_center")
                     smartRestoreState();
                 return;
             case "toggleControlCenter":
@@ -1316,6 +1343,18 @@ PanelWindow {
             notificationExpanded = false;
             islandState = "notification";
             restartAutoHideTimer(notificationAutoHideInterval);
+            // Store in notification history
+                if (notificationHistoryModel) {
+                    notificationHistoryModel.insert(0, {
+                        appName: cleanedAppName !== "" ? cleanedAppName : "Notification",
+                        summary: resolvedSummary,
+                        body: cleanedSummary !== "" ? cleanedBody : "",
+                        timestamp: new Date()
+                    });
+                    if (notificationHistoryModel.count > 50)
+                        notificationHistoryModel.remove(50, notificationHistoryModel.count - 50);
+                }
+
         }
 
         function toggleNotificationExpansionIfNeeded() {
@@ -1415,6 +1454,16 @@ PanelWindow {
             mainCapsule.displayedWidth = mainCapsule.baseTargetWidth;
             stopAutoHideTimer();
         }
+
+        function showNotificationCenter() {
+            cancelSideSwipeSettle();
+            abortSideTransientMode();
+            clearTransientCapsule();
+            islandState = "notification_center";
+            mainCapsule.displayedWidth = mainCapsule.baseTargetWidth;
+            stopAutoHideTimer();
+        }
+
 
         function showWallpaperPicker() {
             cancelSideSwipeSettle();
@@ -1590,6 +1639,8 @@ PanelWindow {
                     return islandContainer.lyricsCapsuleWidth;
                 case "control_center":
                     return 420;
+                case "notification_center":
+                    return 400;
                 case "wallpaper_picker":
                     return 1100;
                 case "expanded":
@@ -1611,6 +1662,8 @@ PanelWindow {
                 switch (islandContainer.islandState) {
                 case "control_center":
                     return 320 + (controlCenterLoader.item ? controlCenterLoader.item.controlCenterExtraHeight : 32);
+                case "notification_center":
+                    return notificationCenterLoader.item ? notificationCenterLoader.item.contentHeight : 200;
                 case "wallpaper_picker":
                     return 260;
                 case "expanded":
@@ -1629,6 +1682,8 @@ PanelWindow {
 
                 switch (islandContainer.islandState) {
                 case "control_center":
+                    return 34;
+                case "notification_center":
                     return 34;
                 case "wallpaper_picker":
                     return 34;
@@ -2222,6 +2277,31 @@ PanelWindow {
                         }
                         onConnectivityPanelRequested: function(kind, open) {
                             root.setConnectivityDetailVisible(kind, open);
+                        }
+                    }
+                }
+            }
+
+            Loader {
+                id: notificationCenterLoader
+                anchors.fill: parent
+                active: islandContainer.notificationCenterLayerVisible
+                asynchronous: false
+                visible: active
+
+                sourceComponent: Component {
+                    NotificationCenterLayer {
+                        notificationModel: islandContainer.notificationHistoryModel
+                        iconFontFamily: root.iconFontFamily
+                        textFontFamily: root.textFontFamily
+                        heroFontFamily: root.heroFontFamily
+
+                        onRequestDismiss: {
+                            islandContainer.smartRestoreState();
+                        }
+
+                        onClearAllRequested: {
+                            islandContainer.notificationHistoryModel.clear();
                         }
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ It's built with Quickshell, QML, and C++/Qt 6. Most of the effort went into maki
 - Memory usage
 - Brightness
 - Cava
+- Storage usage
 
 ### Compositor support
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@
   <a href="#configuration">Configuration</a>
   ·
   <a href="#common-commands">Common Commands</a>
+  ·
+  <a href="#notification-centre">Notification Centre</a>
 </p>
 
 ---
@@ -96,6 +98,7 @@ It's built with Quickshell, QML, and C++/Qt 6. Most of the effort went into maki
 - Wallpaper switcher
 - Workspace overview
 - Custom page
+- Notification Centre
 
 
 
@@ -246,7 +249,46 @@ systemctl --user stop tide-island
 journalctl --user -u tide-island -f
 ```
 
+#### IPC Commands
+
+Tide Island can be controlled remotely via `quickshell ipc call`:
+
+| Command | Action |
+| --- | --- |
+| `quickshell ipc call tide toggleNotificationCenter` | Open or close the Notification Centre |
+| `quickshell ipc call tide openNotificationCenter` | Open the Notification Centre |
+| `quickshell ipc call tide closeNotificationCenter` | Close the Notification Centre |
+
 <br>
+
+## Notification Centre
+
+The Notification Centre is a scrollable history panel that collects all incoming system notifications. It opens as a centred overlay above the island capsule, displaying each notification as a card with the app icon, summary, body, and timestamp.
+
+### Opening the Notification Centre
+
+- **IPC commands** — see [IPC Commands](#common-commands) above
+- **Keybind** — bind a key to call `quickshell ipc call tide toggleNotificationCenter` in your Hyprland config:
+  ```conf
+  bind = $mainMod, N, exec, quickshell ipc call tide toggleNotificationCenter
+  ```
+  Or in Lua:
+  ```lua
+  hl.keybind("$mainMod", "N", "quickshell ipc call tide toggleNotificationCenter")
+  ```
+
+### Behaviour
+
+- Notifications are automatically stored in the history when they arrive via the system notification daemon
+- The list is capped at 50 notifications — oldest entries are removed first
+- Each card shows the app name, summary text, body (if present), and relative timestamp
+- Use **Clear all** in the header to dismiss every notification at once
+- Tap the **✕** button or dismiss to close the panel
+- The panel height adjusts dynamically based on the notification list content
+
+### Dismissing notifications
+
+Individual notifications can be dismissed by tapping the × button on the card. Use **Clear all** to remove all notifications at once.
 
 ## Contributing
 

--- a/qml/controlcenter/NotificationCenterLayer.qml
+++ b/qml/controlcenter/NotificationCenterLayer.qml
@@ -1,0 +1,118 @@
+    import QtQuick
+    import IslandBackend
+    import "../island"
+
+    Item {
+        id: notificationCenter
+
+        signal requestDismiss()
+
+        property var notificationModel: null
+        property string iconFontFamily: userConfig.iconFontFamily
+        property string textFontFamily: userConfig.textFontFamily
+        property string heroFontFamily: userConfig.heroFontFamily
+
+        property color panelBg: "#80000000"
+        property int cardRadius: 14
+        // Exposed for parent to dynamically size the panel
+        readonly property real contentHeight: notificationHistory.listContentHeight + 36 + 20
+
+        signal clearAllRequested()
+
+            // Panel background for blur
+            Rectangle {
+                anchors.fill: parent
+                radius: parent.cardRadius
+                color: "#0d0d0d"
+            }
+
+        Column {
+            anchors.fill: parent
+            spacing: 0
+
+            // Unified header — "Notifications" title + count + clear all + close
+            Item {
+                width: parent.width
+                height: 36
+
+                Text {
+                    anchors.left: parent.left
+                    anchors.leftMargin: 14
+                    anchors.verticalCenter: parent.verticalCenter
+                    id: headerTitle
+                    text: "Notifications"
+                    color: "#f4f5f7"
+                    font.pixelSize: 15
+                    font.family: notificationCenter.heroFontFamily
+                    font.weight: Font.Medium
+                }
+
+                // Count badge
+                Text {
+                    anchors.left: headerTitle.right
+                    anchors.leftMargin: 8
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.verticalCenterOffset: -1
+                    text: notificationModel ? String(notificationModel.count) : ""
+                    color: "#9ca3af"
+                    font.pixelSize: 12
+                    font.family: notificationCenter.textFontFamily
+                    visible: notificationModel && notificationModel.count > 0
+                }
+
+                // Clear All
+                Text {
+                    id: clearBtn
+                    anchors.right: closeBtn.left
+                    anchors.rightMargin: 14
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.verticalCenterOffset: -2
+                    text: "Clear all"
+                    color: notificationModel && notificationModel.count > 0 ? "#f87171" : "transparent"
+                    font.pixelSize: 11
+                    font.family: notificationCenter.textFontFamily
+                    visible: notificationModel && notificationModel.count > 0
+
+                    MouseArea {
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: notificationCenter.clearAllRequested()
+                        onEntered: clearBtn.color = "#fca5a5"
+                        onExited: clearBtn.color = "#f87171"
+                    }
+                }
+
+                Text {
+                    id: closeBtn
+                    anchors.right: parent.right
+                    anchors.rightMargin: 14
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.verticalCenterOffset: 0.5
+                    text: "\u2715"
+                    color: "#9ca3af"
+                    font.pixelSize: 16
+
+                    MouseArea {
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: notificationCenter.requestDismiss()
+                        onEntered: closeBtn.color = "#f4f5f7"
+                        onExited: closeBtn.color = "#9ca3af"
+                    }
+                }
+            }
+
+            // NotificationHistory — cards, no duplicate header
+            NotificationHistory {
+                id: notificationHistory
+                width: parent.width
+                height: parent.height - 36
+                notificationModel: notificationCenter.notificationModel
+                iconFontFamily: notificationCenter.iconFontFamily
+                textFontFamily: notificationCenter.textFontFamily
+                heroFontFamily: notificationCenter.heroFontFamily
+            }
+        }
+    }

--- a/qml/island/IslandSystemState.qml
+++ b/qml/island/IslandSystemState.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import IslandBackend
+import Quickshell.Io
 
 Item {
     id: root
@@ -19,6 +20,7 @@ Item {
     readonly property var configuredLeftSwipeIds: buildNormalizedSwipeItemIds(configuredLeftSwipeItems)
     readonly property bool usesSystemStatsModule: configuredLeftSwipeIds.indexOf("cpu") !== -1
         || configuredLeftSwipeIds.indexOf("ram") !== -1
+    readonly property bool usesStorageModule: configuredLeftSwipeIds.indexOf("storage") !== -1
     readonly property bool usesCavaModule: configuredLeftSwipeIds.indexOf("cava") !== -1
     readonly property bool hasCustomLeftItems: customLeftItems.length > 0
     readonly property string systemServicesClientId: "island-system-state-" + Math.random().toString(36).slice(2)
@@ -42,6 +44,8 @@ Item {
     property real currentCpuUsage: -1
     property real currentRamUsage: -1
     property var cavaLevels: [0, 0, 0, 0, 0, 0, 0, 0]
+    property real currentStorageUsage: -1
+    readonly property string storageStatusIcon: "\u{F1C0}"
     property var customLeftItems: []
 
     property string _lastChargeStatus: SysBackend.batteryStatus
@@ -59,6 +63,7 @@ Item {
         updateCavaSubscription();
     }
     onUsesSystemStatsModuleChanged: refreshMissingValues()
+    onUsesStorageModuleChanged: refreshMissingValues()
     onUsesCavaModuleChanged: updateCavaSubscription()
     onCustomSwipeActiveChanged: updateCavaSubscription()
     onBatteryCapacityChanged: syncCustomLeftItems()
@@ -68,6 +73,7 @@ Item {
     onCurrentBrightnessChanged: syncCustomLeftItems()
     onCurrentCpuUsageChanged: syncCustomLeftItems()
     onCurrentRamUsageChanged: syncCustomLeftItems()
+    onCurrentStorageUsageChanged: syncCustomLeftItems()
     onCurrentWorkspaceChanged: syncCustomLeftItems()
     onTimeTextChanged: syncCustomLeftItems()
     onDateTextChanged: syncCustomLeftItems()
@@ -151,6 +157,8 @@ Item {
             SystemServices.requestVolume();
         if (usesSystemStatsModule)
             SystemServices.requestSystemStats();
+        if (usesStorageModule)
+            storagePollTimer.restart();
     }
 
     function updateCavaSubscription() {
@@ -221,6 +229,12 @@ Item {
             };
         case "cava":
             return { id: itemId, kind: "cava" };
+        case "storage":
+            return {
+                id: itemId,
+                icon: storageStatusIcon,
+                text: currentStorageUsage >= 0 ? Math.round(currentStorageUsage) + "%" : "--%"
+            };
         default:
             return null;
         }
@@ -319,6 +333,34 @@ Item {
 
         onTriggered: SystemServices.requestSystemStats()
     }
+    Process {
+        id: storagePollProcess
+        command: ["df", "--output=pcent", "/"]
+        running: false
+
+        stdout: SplitParser {
+            onRead: function(line) {
+                const trimmed = line.trim();
+                if (trimmed === "" || trimmed.indexOf("Use%") >= 0)
+                    return;
+                const pct = parseInt(trimmed.replace("%", ""));
+                if (!isNaN(pct))
+                    root.currentStorageUsage = pct;
+            }
+        }
+    }
+
+    Timer {
+        id: storagePollTimer
+
+        interval: 10000
+        repeat: true
+        running: root.usesStorageModule
+        triggeredOnStart: true
+
+        onTriggered: storagePollProcess.running = true
+    }
+
 
     Connections {
         target: SystemServices

--- a/qml/island/NotificationHistory.qml
+++ b/qml/island/NotificationHistory.qml
@@ -1,0 +1,252 @@
+import QtQuick
+    import QtQuick.Controls
+    import IslandBackend
+
+    Item {
+        id: root
+
+        readonly property var userConfig: UserConfig
+        property var notificationModel: null
+        property string iconFontFamily: userConfig.iconFontFamily
+        property string textFontFamily: userConfig.textFontFamily
+        property string heroFontFamily: userConfig.heroFontFamily
+
+        // One UI color scheme
+        property color textPrimary: "#f4f5f7"
+        property color textSecondary: "#9ca3af"
+        property color cardBg: "#1c1c1e"
+        property color cardBorder: "#484855"
+        property color cardHover: "#262630"
+        property color panelBg: "#80000000"
+
+        readonly property int cardRadius: 14
+        readonly property int cardPadding: 12
+        readonly property int cardGap: 10
+        readonly property int cardHeight: 68
+        readonly property int maxVisibleItems: 3
+        readonly property int itemCount: notificationModel ? notificationModel.count : 0
+        readonly property bool hasNotifications: itemCount > 0
+
+        // listContentHeight reads actual ListView contentHeight, capped at maxVisibleItems cards
+        readonly property real listContentHeight: hasNotifications
+            ? Math.min(listView.contentHeight, maxVisibleItems * cardHeight + (maxVisibleItems - 1) * cardGap)
+            : 80
+
+
+        signal clearAllRequested()
+
+        // Deterministic color per app name
+        function appColor(name) {
+            if (!name || name === "") return "#6b7280";
+            const colors = ["#60a5fa", "#34d399", "#f472b6", "#fbbf24", "#a78bfa", "#fb923c", "#2dd4bf", "#f87171", "#a3e635", "#818cf8"];
+            let hash = 0;
+            for (let i = 0; i < name.length; i++)
+                hash = (hash * 31 + name.charCodeAt(i)) | 0;
+            return colors[Math.abs(hash) % colors.length];
+        }
+
+        function relativeTime(timestamp) {
+            if (!timestamp) return "";
+            const now = new Date();
+            const diff = Math.floor((now - timestamp) / 1000);
+            if (diff < 60) return "now";
+            if (diff < 3600) return Math.floor(diff / 60) + "m";
+            if (diff < 86400) return Math.floor(diff / 3600) + "h";
+            return Math.floor(diff / 86400) + "d";
+        }
+
+        Column {
+            anchors.fill: parent
+            spacing: 0
+
+            // Card list — capped at maxVisibleItems, scrollable
+            Item {
+                clip: true
+                width: parent.width
+                height: root.hasNotifications ? root.listContentHeight : parent.height
+
+                // Empty state — only rendered/visible when there are no notifications
+                Column {
+                    anchors.centerIn: parent
+                    spacing: 8
+                    visible: !root.hasNotifications
+
+                    // Empty icon — vector-drawn bell, respects color (emoji glyphs ignore color)
+                    Canvas {
+                        id: bellIcon
+                        width: 28
+                        height: 28
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        property color bellColor: "#9ca3af"
+
+                        onPaint: {
+                            var ctx = getContext("2d");
+                            ctx.reset();
+                            ctx.strokeStyle = bellColor;
+                            ctx.fillStyle = bellColor;
+                            ctx.lineWidth = 1.5;
+
+                            // Bell body
+                            ctx.beginPath();
+                            ctx.arc(width / 2, height / 2 - 2, width / 3, Math.PI, 0, false);
+                            ctx.lineTo(width - 6, height - 8);
+                            ctx.lineTo(6, height - 8);
+                            ctx.closePath();
+                            ctx.fill();
+
+                            // Clapper
+                            ctx.beginPath();
+                            ctx.arc(width / 2, height - 5, 2.5, 0, 2 * Math.PI);
+                            ctx.fill();
+                        }
+                    }
+
+                    // Title
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "No notifications"
+                        color: root.textSecondary
+                        font.pixelSize: 14
+                        font.family: root.textFontFamily
+                    }
+
+                    // Subtitle
+                    Text {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "You are all caught up"
+                        color: "#6b7280"
+                        font.pixelSize: 11
+                        font.family: root.textFontFamily
+                    }
+                }
+
+                ListView {
+                    id: listView
+                    anchors.fill: parent
+                    anchors.leftMargin: 10
+                    anchors.rightMargin: 10
+                    anchors.topMargin: 0
+                    anchors.bottomMargin: 0
+                    visible: root.hasNotifications
+                    clip: true
+                    interactive: contentHeight > height
+                    boundsBehavior: Flickable.StopAtBounds
+                    model: root.notificationModel
+                    currentIndex: -1
+                    spacing: root.cardGap
+
+                    // Scroll indicator when >3 notifications
+                    ScrollBar.vertical: ScrollBar {
+                        active: true
+                        policy: ScrollBar.AsNeeded
+                        width: 4
+
+                        contentItem: Rectangle {
+                            radius: 2
+                            color: "#555566"
+                        }
+
+                        background: Rectangle {
+                            color: "transparent"
+                        }
+                    }
+
+                    delegate: Item {
+                        width: listView.width
+                        id: delegateItem
+
+                        height: Math.max(48, textContent.implicitHeight + 24)
+                        readonly property string notifTime: model.timestamp
+                            ? root.relativeTime(model.timestamp)
+                            : ""
+                        readonly property string appName: model.appName !== "" ? model.appName : "Notification"
+                        readonly property color accentColor: root.appColor(appName)
+
+                        // Card surface with border
+                        Rectangle {
+                            anchors.fill: parent
+                            radius: root.cardRadius
+                            color: mouseArea.containsMouse ? root.cardHover : root.cardBg
+
+                            // Subtle 1px border
+                            Rectangle {
+                                anchors.fill: parent
+                                radius: root.cardRadius
+                                color: "transparent"
+                                border.color: root.cardBorder
+                                border.width: 1
+                            }
+
+
+                            // Content layout
+                            Row {
+                                anchors.left: parent.left
+                                anchors.leftMargin: root.cardPadding + 6
+                                anchors.right: parent.right
+                                anchors.rightMargin: root.cardPadding + 4
+                                anchors.verticalCenter: parent.verticalCenter
+                                spacing: 10
+
+                                // Colored app dot
+                                Rectangle {
+                                    width: 8
+                                    height: 8
+                                    radius: 4
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    color: accentColor
+                                }
+
+                                // Text area
+                                Column {
+                                    id: textContent
+                                    width: parent.width - 8 - 10 - 30 - 4
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    spacing: 2
+
+                                    Text {
+                                        width: parent.width
+                                        text: appName
+                                        color: root.textSecondary
+                                        font.pixelSize: 11
+                                        font.family: root.textFontFamily
+                                        font.weight: Font.Medium
+                                        elide: Text.ElideRight
+                                    }
+
+                                    Text {
+                                        width: parent.width
+                                        text: model.summary + (model.body !== "" && model.body !== model.summary ? " \u2014 " + model.body : "")
+                                        color: root.textPrimary
+                                        font.pixelSize: 13
+                                        font.family: root.textFontFamily
+                                        font.weight: Font.DemiBold
+                                        wrapMode: Text.WordWrap
+                                        maximumLineCount: 2
+                                        elide: Text.ElideRight
+                                        lineHeight: 1.2
+                                    }
+                                }
+
+                                // Timestamp
+                                Text {
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    text: notifTime
+                                    color: root.textSecondary
+                                    font.pixelSize: 10
+                                    font.family: root.textFontFamily
+                                    horizontalAlignment: Text.AlignRight
+                                }
+                            }
+                        }
+
+                        MouseArea {
+                            id: mouseArea
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                        }
+                    }
+                }
+            }
+        }
+    }

--- a/shell.qml
+++ b/shell.qml
@@ -235,6 +235,10 @@ Scope {
             shellRoot.forFocusedWindow((window) => window.toggleControlCenterWindow());
         }
 
+        function toggleNotificationCenter() {
+            shellRoot.forFocusedWindow((window) => window.toggleNotificationCenterWindow());
+        }
+
         function toggleWallpaperPicker() {
             shellRoot.forFocusedWindow((window) => window.toggleWallpaperPickerWindow());
         }


### PR DESCRIPTION
- Notification history stored in ListModel (capped at 50 entries)
- NotificationCenterLayer: scrollable panel with clear-all and dismiss
- NotificationHistory: card-based list with app icon, summary, body, timestamp
- IPC commands: toggleNotificationCenter, openNotificationCenter, closeNotificationCenter
- Dynamic sizing: panel height adjusts to content
- All notifications auto-captured via showNotificationCapsule