### PR TITLE
Ensure NoDisplay is set to true in desktop entry

### DIFF
--- a/tide-island.desktop
+++ b/tide-island.desktop
@@ -7,3 +7,4 @@ Terminal=false
 Type=Application
 Categories=Utility;
 Keywords=hyprland;niri;quickshell;island;
+NoDisplay=true


### PR DESCRIPTION
Set the `NoDisplay` property to true in the desktop entry to prevent it from appearing in menus.